### PR TITLE
Add `tpl` as File Type and add Key Equivalent

### DIFF
--- a/Syntaxes/Smarty.plist
+++ b/Syntaxes/Smarty.plist
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
-	<array/>
+	<array>
+		<string>tpl</string>
+	</array>
 	<key>foldingStartMarker</key>
 	<string>(&lt;(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\b.*?&gt;|\{\{?(if|foreach|capture|literal|foreach|php|section|strip)|\{\s*$)</string>
 	<key>foldingStopMarker</key>
 	<string>(&lt;/(?i:(head|table|tr|div|style|script|ul|ol|form|dl))&gt;|\{\{?/(if|foreach|capture|literal|foreach|php|section|strip)|(^|\s)\})</string>
+	<key>keyEquivalent</key>
+	<string>^~S</string>
 	<key>name</key>
 	<string>Smarty</string>
 	<key>patterns</key>


### PR DESCRIPTION
Adding this enables automatic source syntax for tpl files (Smarty templates) and adds a standard-like shortcut to change the syntax via keyboard.
