### PR TITLE
Improved support for code folding

### DIFF
--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -9,9 +9,9 @@
 	<key>settings</key>
 	<dict>
 		<key>foldingStartMarker</key>
-		<string>\{%?</string>
+		<string>\{%?(\*|((if|section|foreach|block|switch|case|capture).*)|(literal|strip)%?\})\s*$</string>
 		<key>foldingStopMarker</key>
-		<string>%?\}</string>
+		<string>(^(\s*?)\*|(\{%?\/(if|section|literal|foreach|block|switch|case|capture|strip))%?\})</string>
 	</dict>
 	<key>uuid</key>
 	<string>5D1338FA-DE7B-4200-A3BC-C148344A5BED</string>


### PR DESCRIPTION
Switch/case are not supported by Smarty without a third-party plugin, but since the main grammar supports them, I included them as folding patterns
Retains support for the {%asp%} style tags which the bundle appears to use throughout, although I'm not convinced these are even supported by Smarty
